### PR TITLE
Changed nomenclature from pysingfel to skopi in unit tests

### DIFF
--- a/examples/scripts/cspi_generate_synthetic_dataset.py
+++ b/examples/scripts/cspi_generate_synthetic_dataset.py
@@ -14,7 +14,7 @@ from PIL import Image
 
 import h5py as h5
 
-import skopi as sp
+import skopi as sk
 
 
 """
@@ -82,13 +82,13 @@ def main():
     
     # PDB
     print("Load PDB: {}".format(pdb_file))
-    particle = sp.Particle()
+    particle = sk.Particle()
     particle.read_pdb(pdb_file, ff='WK')
     atomic_coordinates = particle.atom_pos
     
     # Beam parameters
     print("Load beam parameters: {}".format(pdb_file))
-    beam = sp.Beam(beam_file)
+    beam = sk.Beam(beam_file)
 
     # Increase the beam fluence
     if not np.isclose(beam_fluence_increase_factor, 1.0):
@@ -99,7 +99,7 @@ def main():
 
     # Geometry of detector
     print("Load detector geometry: {}".format(geom_file))
-    det = sp.PnccdDetector(geom=geom_file, beam=beam)
+    det = sk.PnccdDetector(geom=geom_file, beam=beam)
 
     
     # Simulate the SPI Experiment
@@ -107,7 +107,7 @@ def main():
     
     tic = time.time()
     
-    experiment = sp.SPIExperiment(det, beam, particle)
+    experiment = sk.SPIExperiment(det, beam, particle)
     
     toc = time.time()
 
@@ -115,7 +115,7 @@ def main():
 
     # Generate random orientations
     print("Generating random orientations as uniform quaternions")
-    orientations = sp.get_uniform_quat(dataset_size, True)
+    orientations = sk.get_uniform_quat(dataset_size, True)
     
     # Get diffraction pattern shape
     diffraction_pattern_height = det.detector_pixel_num_x.item()

--- a/examples/scripts/cspi_generate_synthetic_dataset.py
+++ b/examples/scripts/cspi_generate_synthetic_dataset.py
@@ -14,14 +14,14 @@ from PIL import Image
 
 import h5py as h5
 
-import pysingfel as ps
+import skopi as sp
 
 
 """
 
 Deeban Ramalingam (deebanr@slac.stanford.edu)
 
-This script generates a synthetic dataset of diffraction patterns and their associated orientations for computational Single Particle Imaging (cSPI). This script uses Pysingfel to simulate an SPI Experiment.
+This script generates a synthetic dataset of diffraction patterns and their associated orientations for computational Single Particle Imaging (cSPI). This script uses Skopi to simulate an SPI Experiment.
 
 How to run this script:
 
@@ -35,7 +35,7 @@ Examples on how to run this script:
 
 Tips on using this script:
 
-1. For an example config file, look at: pysingfel/examples/scripts/cspi_generate_synthetic_dataset_config.json
+1. For an example config file, look at: skopi/examples/scripts/cspi_generate_synthetic_dataset_config.json
 
 2. Use the previously defined datasets in this file to add or modify an existing experiment of your choice.
 
@@ -82,13 +82,13 @@ def main():
     
     # PDB
     print("Load PDB: {}".format(pdb_file))
-    particle = ps.Particle()
+    particle = sp.Particle()
     particle.read_pdb(pdb_file, ff='WK')
     atomic_coordinates = particle.atom_pos
     
     # Beam parameters
     print("Load beam parameters: {}".format(pdb_file))
-    beam = ps.Beam(beam_file)
+    beam = sp.Beam(beam_file)
 
     # Increase the beam fluence
     if not np.isclose(beam_fluence_increase_factor, 1.0):
@@ -99,7 +99,7 @@ def main():
 
     # Geometry of detector
     print("Load detector geometry: {}".format(geom_file))
-    det = ps.PnccdDetector(geom=geom_file, beam=beam)
+    det = sp.PnccdDetector(geom=geom_file, beam=beam)
 
     
     # Simulate the SPI Experiment
@@ -107,7 +107,7 @@ def main():
     
     tic = time.time()
     
-    experiment = ps.SPIExperiment(det, beam, particle)
+    experiment = sp.SPIExperiment(det, beam, particle)
     
     toc = time.time()
 
@@ -115,7 +115,7 @@ def main():
 
     # Generate random orientations
     print("Generating random orientations as uniform quaternions")
-    orientations = ps.get_uniform_quat(dataset_size, True)
+    orientations = sp.get_uniform_quat(dataset_size, True)
     
     # Get diffraction pattern shape
     diffraction_pattern_height = det.detector_pixel_num_x.item()

--- a/examples/scripts/cspi_generate_synthetic_dataset_double-hit_mpi_hybrid.py
+++ b/examples/scripts/cspi_generate_synthetic_dataset_double-hit_mpi_hybrid.py
@@ -13,7 +13,7 @@ mpiexec -n 16 python cspi_generate_synthetic_dataset_double-hit_mpi_hybrid.py --
 
 Tips on using this script:
 
-1. For an example config file, look at: pysingfel/examples/scripts/cspi_generate_synthetic_dataset_config.json
+1. For an example config file, look at: skopi/examples/scripts/cspi_generate_synthetic_dataset_config.json
 
 2. Use the previously defined datasets in this file to add or modify an existing dataset of your choice.
 
@@ -68,8 +68,8 @@ from tqdm import tqdm
 from PIL import Image
 import h5py as h5
 
-import pysingfel as ps
-from pysingfel.util import asnumpy, xp
+import skopi as sp
+from skopi.util import asnumpy, xp
 
 
 def main():
@@ -124,14 +124,14 @@ def main():
     photons_max = np.iinfo(photons_dtype).max
 
     # Load beam parameters
-    beam = ps.Beam(beam_file)
+    beam = sp.Beam(beam_file)
 
     # Increase the beam fluence
     if not np.isclose(beam_fluence_increase_factor, 1.0):
         beam.set_photons_per_pulse(beam_fluence_increase_factor * beam.get_photons_per_pulse())
 
     # Load geometry of detector
-    det = ps.PnccdDetector(geom=geom_file, beam=beam)
+    det = sp.PnccdDetector(geom=geom_file, beam=beam)
 
     # Get the shape of the diffraction pattern
     diffraction_pattern_height = det.detector_pixel_num_x.item()
@@ -146,10 +146,10 @@ def main():
         print("(Master) Generate {} orientations".format(dataset_size))
 
         # Generate orientations for the first particle
-        first_particle_orientations = ps.get_uniform_quat(dataset_size, True)
+        first_particle_orientations = sp.get_uniform_quat(dataset_size, True)
 
         # Generate orientations for the second particle
-        second_particle_orientations = ps.get_random_quat(dataset_size)
+        second_particle_orientations = sp.get_random_quat(dataset_size)
 
         # Assemble the orientations for both particles
         first_particle_orientations_ = first_particle_orientations[np.newaxis]
@@ -180,15 +180,15 @@ def main():
 
         # Load PDB
         print("(GPU 0) Reading PDB file: {}".format(pdb_file))
-        particle = ps.Particle()
+        particle = sp.Particle()
         particle.read_pdb(pdb_file, ff='WK')
 
         # Calculate diffraction volume
         print("(GPU 0) Calculating diffraction volume")
-        experiment = ps.SPIExperiment(det, beam, particle)
+        experiment = sp.SPIExperiment(det, beam, particle)
 
     else:
-        experiment = ps.SPIExperiment(det, beam, None)
+        experiment = sp.SPIExperiment(det, beam, None)
 
     # Soon obsolete way to handle multiple particles in the beamline
     experiment.set_multi_particle_hit(True)

--- a/examples/scripts/cspi_generate_synthetic_dataset_double-hit_mpi_hybrid.py
+++ b/examples/scripts/cspi_generate_synthetic_dataset_double-hit_mpi_hybrid.py
@@ -68,7 +68,7 @@ from tqdm import tqdm
 from PIL import Image
 import h5py as h5
 
-import skopi as sp
+import skopi as sk
 from skopi.util import asnumpy, xp
 
 
@@ -124,14 +124,14 @@ def main():
     photons_max = np.iinfo(photons_dtype).max
 
     # Load beam parameters
-    beam = sp.Beam(beam_file)
+    beam = sk.Beam(beam_file)
 
     # Increase the beam fluence
     if not np.isclose(beam_fluence_increase_factor, 1.0):
         beam.set_photons_per_pulse(beam_fluence_increase_factor * beam.get_photons_per_pulse())
 
     # Load geometry of detector
-    det = sp.PnccdDetector(geom=geom_file, beam=beam)
+    det = sk.PnccdDetector(geom=geom_file, beam=beam)
 
     # Get the shape of the diffraction pattern
     diffraction_pattern_height = det.detector_pixel_num_x.item()
@@ -146,10 +146,10 @@ def main():
         print("(Master) Generate {} orientations".format(dataset_size))
 
         # Generate orientations for the first particle
-        first_particle_orientations = sp.get_uniform_quat(dataset_size, True)
+        first_particle_orientations = sk.get_uniform_quat(dataset_size, True)
 
         # Generate orientations for the second particle
-        second_particle_orientations = sp.get_random_quat(dataset_size)
+        second_particle_orientations = sk.get_random_quat(dataset_size)
 
         # Assemble the orientations for both particles
         first_particle_orientations_ = first_particle_orientations[np.newaxis]
@@ -180,15 +180,15 @@ def main():
 
         # Load PDB
         print("(GPU 0) Reading PDB file: {}".format(pdb_file))
-        particle = sp.Particle()
+        particle = sk.Particle()
         particle.read_pdb(pdb_file, ff='WK')
 
         # Calculate diffraction volume
         print("(GPU 0) Calculating diffraction volume")
-        experiment = sp.SPIExperiment(det, beam, particle)
+        experiment = sk.SPIExperiment(det, beam, particle)
 
     else:
-        experiment = sp.SPIExperiment(det, beam, None)
+        experiment = sk.SPIExperiment(det, beam, None)
 
     # Soon obsolete way to handle multiple particles in the beamline
     experiment.set_multi_particle_hit(True)

--- a/examples/scripts/cspi_generate_synthetic_dataset_mpi_hybrid.py
+++ b/examples/scripts/cspi_generate_synthetic_dataset_mpi_hybrid.py
@@ -13,7 +13,7 @@ mpiexec -n 16 python cspi_generate_synthetic_dataset_mpi_hybrid.py --config cspi
 
 Tips on using this script:
 
-1. For an example config file, look at: pysingfel/examples/scripts/cspi_generate_synthetic_dataset_config.json
+1. For an example config file, look at: skopi/examples/scripts/cspi_generate_synthetic_dataset_config.json
 
 2. Use the previously defined datasets in this file to add or modify an existing dataset of your choice.
 

--- a/skopi/beam/tests/test_beam_base.py
+++ b/skopi/beam/tests/test_beam_base.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import pytest
 
-import pysingfel as ps
+import skopi as sp
 
 
 WAVELENGTH = 1e-10
@@ -13,21 +13,21 @@ FLUENCE = 1e12
 
 
 def test_wavelength():
-    beam = ps.Beam(wavelength=WAVELENGTH, focus_radius=DIM, fluence=FLUENCE)
+    beam = sp.Beam(wavelength=WAVELENGTH, focus_radius=DIM, fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
     assert np.isclose(beam.photon_energy, PHOTON_ENERGY)
 
 
 def test_wavenumber():
-    beam = ps.Beam(wavenumber=WAVENUMBER, focus_radius=DIM, fluence=FLUENCE)
+    beam = sp.Beam(wavenumber=WAVENUMBER, focus_radius=DIM, fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
     assert np.isclose(beam.photon_energy, PHOTON_ENERGY)
 
 
 def test_photon_energy():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
@@ -36,24 +36,24 @@ def test_photon_energy():
 
 def test_wavelength_wavenumber_clash():
     with pytest.raises(TypeError):
-        beam = ps.Beam(wavelength=WAVELENGTH, wavenumber=WAVENUMBER,
+        beam = sp.Beam(wavelength=WAVELENGTH, wavenumber=WAVENUMBER,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_wavelength_photon_energy_clash():
     with pytest.raises(TypeError):
-        beam = ps.Beam(wavelength=WAVELENGTH, photon_energy=PHOTON_ENERGY,
+        beam = sp.Beam(wavelength=WAVELENGTH, photon_energy=PHOTON_ENERGY,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_wavenumber_photon_energy_clash():
     with pytest.raises(TypeError):
-        beam = ps.Beam(wavenumber=WAVENUMBER, photon_energy=PHOTON_ENERGY,
+        beam = sp.Beam(wavenumber=WAVENUMBER, photon_energy=PHOTON_ENERGY,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_circle_radius():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, 2*DIM, atol=1e-14)
@@ -63,7 +63,7 @@ def test_circle_radius():
 
 
 def test_circle_diameter():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                    focus_shape="circle", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -74,12 +74,12 @@ def test_circle_diameter():
 
 def test_circle_double_diameter_clash():
     with pytest.raises(TypeError):
-        beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_y=1.1*DIM, focus_shape="circle", fluence=FLUENCE)
 
 
 def test_ellipse():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                    focus_shape="ellipse", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -90,12 +90,12 @@ def test_ellipse():
 
 def test_ellipse_lack_y():
     with pytest.raises(TypeError):
-        beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_shape="ellipse", fluence=FLUENCE)
 
 
 def test_square():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                    focus_shape="square", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -106,12 +106,12 @@ def test_square():
 
 def test_square_y_clash():
     with pytest.raises(TypeError):
-        beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                        focus_shape="square", fluence=FLUENCE)
 
 
 def test_rectangle():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                    focus_shape="rectangle", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -122,12 +122,12 @@ def test_rectangle():
 
 def test_rectangle_lack_y():
     with pytest.raises(TypeError):
-        beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_shape="rectangle", fluence=FLUENCE)
 
 
 def test_fluence():
-    beam = ps.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    focus_shape="circle", fluence=FLUENCE)
     assert np.isclose(beam.get_photons_per_pulse(), FLUENCE)
     assert np.isclose(beam.get_photons_per_pulse_per_area(),
@@ -136,7 +136,7 @@ def test_fluence():
 
 def test_file():
     ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
-    beam = ps.Beam(ex_dir_+'/input/beam/amo86615.beam')
+    beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(beam.photon_energy, 4600)
     assert np.isclose(beam.get_photons_per_pulse(), 1e12)

--- a/skopi/beam/tests/test_beam_base.py
+++ b/skopi/beam/tests/test_beam_base.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import pytest
 
-import skopi as sp
+import skopi as sk
 
 
 WAVELENGTH = 1e-10
@@ -13,21 +13,21 @@ FLUENCE = 1e12
 
 
 def test_wavelength():
-    beam = sp.Beam(wavelength=WAVELENGTH, focus_radius=DIM, fluence=FLUENCE)
+    beam = sk.Beam(wavelength=WAVELENGTH, focus_radius=DIM, fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
     assert np.isclose(beam.photon_energy, PHOTON_ENERGY)
 
 
 def test_wavenumber():
-    beam = sp.Beam(wavenumber=WAVENUMBER, focus_radius=DIM, fluence=FLUENCE)
+    beam = sk.Beam(wavenumber=WAVENUMBER, focus_radius=DIM, fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
     assert np.isclose(beam.photon_energy, PHOTON_ENERGY)
 
 
 def test_photon_energy():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    fluence=FLUENCE)
     assert np.isclose(beam.wavelength, WAVELENGTH, atol=1e-14)
     assert np.isclose(beam.wavenumber, WAVENUMBER)
@@ -36,24 +36,24 @@ def test_photon_energy():
 
 def test_wavelength_wavenumber_clash():
     with pytest.raises(TypeError):
-        beam = sp.Beam(wavelength=WAVELENGTH, wavenumber=WAVENUMBER,
+        beam = sk.Beam(wavelength=WAVELENGTH, wavenumber=WAVENUMBER,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_wavelength_photon_energy_clash():
     with pytest.raises(TypeError):
-        beam = sp.Beam(wavelength=WAVELENGTH, photon_energy=PHOTON_ENERGY,
+        beam = sk.Beam(wavelength=WAVELENGTH, photon_energy=PHOTON_ENERGY,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_wavenumber_photon_energy_clash():
     with pytest.raises(TypeError):
-        beam = sp.Beam(wavenumber=WAVENUMBER, photon_energy=PHOTON_ENERGY,
+        beam = sk.Beam(wavenumber=WAVENUMBER, photon_energy=PHOTON_ENERGY,
                        focus_radius=DIM, fluence=FLUENCE)
 
 
 def test_circle_radius():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, 2*DIM, atol=1e-14)
@@ -63,7 +63,7 @@ def test_circle_radius():
 
 
 def test_circle_diameter():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                    focus_shape="circle", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -74,12 +74,12 @@ def test_circle_diameter():
 
 def test_circle_double_diameter_clash():
     with pytest.raises(TypeError):
-        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_y=1.1*DIM, focus_shape="circle", fluence=FLUENCE)
 
 
 def test_ellipse():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                    focus_shape="ellipse", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -90,12 +90,12 @@ def test_ellipse():
 
 def test_ellipse_lack_y():
     with pytest.raises(TypeError):
-        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_shape="ellipse", fluence=FLUENCE)
 
 
 def test_square():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                    focus_shape="square", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -106,12 +106,12 @@ def test_square():
 
 def test_square_y_clash():
     with pytest.raises(TypeError):
-        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+        beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                        focus_shape="square", fluence=FLUENCE)
 
 
 def test_rectangle():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM, focus_y=2*DIM,
                    focus_shape="rectangle", fluence=FLUENCE)
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(focus_x, DIM, atol=1e-14)
@@ -122,12 +122,12 @@ def test_rectangle():
 
 def test_rectangle_lack_y():
     with pytest.raises(TypeError):
-        beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
+        beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_x=DIM,
                        focus_shape="rectangle", fluence=FLUENCE)
 
 
 def test_fluence():
-    beam = sp.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
+    beam = sk.Beam(photon_energy=PHOTON_ENERGY, focus_radius=DIM,
                    focus_shape="circle", fluence=FLUENCE)
     assert np.isclose(beam.get_photons_per_pulse(), FLUENCE)
     assert np.isclose(beam.get_photons_per_pulse_per_area(),
@@ -136,7 +136,7 @@ def test_fluence():
 
 def test_file():
     ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
-    beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
+    beam = sk.Beam(ex_dir_+'/input/beam/amo86615.beam')
     focus_x, focus_y, focus_shape = beam.get_focus()
     assert np.isclose(beam.photon_energy, 4600)
     assert np.isclose(beam.get_photons_per_pulse(), 1e12)

--- a/skopi/detector/tests/test_autoranging_detector.py
+++ b/skopi/detector/tests/test_autoranging_detector.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import pytest
 
-import skopi as sp
+import skopi as sk
 import skopi.gpu as sg
 import skopi.constants as cst
 from skopi.build_autoranging_frames import BuildAutoRangeFrames
@@ -27,11 +27,11 @@ class TestAutorangingDetector(object):
         ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
 
         # Load beam
-        beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
+        beam = sk.Beam(ex_dir_+'/input/beam/amo86615.beam')
 
         # Load and initialize the detector
         np.random.seed(0)
-        det = sp.Epix10kDetector(
+        det = sk.Epix10kDetector(
             geom=ex_dir_+'/input/lcls/xcsx35617/'
                  'Epix10ka2M::CalibV1/XcsEndstation.0:Epix10ka2M.0/geometry/0-end.data',
             run_num=0,
@@ -42,7 +42,7 @@ class TestAutorangingDetector(object):
         cls.pos_recip = det.pixel_position_reciprocal
 
         # Ref Particle
-        cls.particle_0 = sp.Particle()
+        cls.particle_0 = sk.Particle()
         cls.particle_0.create_from_atoms([  # Angstrom
             ("O", cst.vecx),
             ("O", 2*cst.vecy),
@@ -53,7 +53,7 @@ class TestAutorangingDetector(object):
 
         # Second Particle
         cls.part_coord_1 = np.array((0.5, 0.2, 0.1))  # Angstrom
-        cls.particle_1 = sp.Particle()
+        cls.particle_1 = sk.Particle()
         cls.particle_1.create_from_atoms([  # Angstrom
             ("O", cst.vecx + cls.part_coord_1),
             ("O", 2*cst.vecy + cls.part_coord_1),

--- a/skopi/detector/tests/test_autoranging_detector.py
+++ b/skopi/detector/tests/test_autoranging_detector.py
@@ -2,10 +2,10 @@ import numpy as np
 import os
 import pytest
 
-import pysingfel as ps
-import pysingfel.gpu as pg
-import pysingfel.constants as cst
-from pysingfel.build_autoranging_frames import BuildAutoRangeFrames
+import skopi as sp
+import skopi.gpu as sg
+import skopi.constants as cst
+from skopi.build_autoranging_frames import BuildAutoRangeFrames
 
 global psana_version
 try:
@@ -27,11 +27,11 @@ class TestAutorangingDetector(object):
         ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
 
         # Load beam
-        beam = ps.Beam(ex_dir_+'/input/beam/amo86615.beam')
+        beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
 
         # Load and initialize the detector
         np.random.seed(0)
-        det = ps.Epix10kDetector(
+        det = sp.Epix10kDetector(
             geom=ex_dir_+'/input/lcls/xcsx35617/'
                  'Epix10ka2M::CalibV1/XcsEndstation.0:Epix10ka2M.0/geometry/0-end.data',
             run_num=0,
@@ -42,25 +42,25 @@ class TestAutorangingDetector(object):
         cls.pos_recip = det.pixel_position_reciprocal
 
         # Ref Particle
-        cls.particle_0 = ps.Particle()
+        cls.particle_0 = sp.Particle()
         cls.particle_0.create_from_atoms([  # Angstrom
             ("O", cst.vecx),
             ("O", 2*cst.vecy),
             ("O", 3*cst.vecz),
         ])
-        cls.pattern_0 = pg.calculate_diffraction_pattern_gpu(
+        cls.pattern_0 = sg.calculate_diffraction_pattern_gpu(
             cls.pos_recip, cls.particle_0, return_type="complex_field")
 
         # Second Particle
         cls.part_coord_1 = np.array((0.5, 0.2, 0.1))  # Angstrom
-        cls.particle_1 = ps.Particle()
+        cls.particle_1 = sp.Particle()
         cls.particle_1.create_from_atoms([  # Angstrom
             ("O", cst.vecx + cls.part_coord_1),
             ("O", 2*cst.vecy + cls.part_coord_1),
             ("O", 3*cst.vecz + cls.part_coord_1),
         ])
         cls.part_coord_1 *= 1e-10  # Angstrom -> meter
-        cls.pattern_1 = pg.calculate_diffraction_pattern_gpu(
+        cls.pattern_1 = sg.calculate_diffraction_pattern_gpu(
             cls.pos_recip, cls.particle_1, return_type="complex_field")
 
         # Flat Field

--- a/skopi/detector/tests/test_detector_base.py
+++ b/skopi/detector/tests/test_detector_base.py
@@ -2,10 +2,10 @@ import numpy as np
 import os
 import pytest
 
-import pysingfel as ps
-import pysingfel.gpu as pg
-import pysingfel.constants as cst
-from pysingfel.util import xp
+import skopi as sp
+import skopi.gpu as sg
+import skopi.constants as cst
+from skopi.util import xp
 
 import six
 if six.PY2:
@@ -21,10 +21,10 @@ class TestDetectorBase(object):
         ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
 
         # Load beam
-        beam = ps.Beam(ex_dir_+'/input/beam/amo86615.beam')
+        beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
 
         # Load and initialize the detector
-        det = ps.PnccdDetector(
+        det = sp.PnccdDetector(
             geom=ex_dir_+'/input/lcls/amo86615/'
                  'PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data',
             beam=beam)
@@ -33,25 +33,25 @@ class TestDetectorBase(object):
         cls.pos_recip = det.pixel_position_reciprocal
 
         # Ref Particle
-        cls.particle_0 = ps.Particle()
+        cls.particle_0 = sp.Particle()
         cls.particle_0.create_from_atoms([  # Angstrom
             ("O", cst.vecx),
             ("O", 2*cst.vecy),
             ("O", 3*cst.vecz),
         ])
-        cls.pattern_0 = pg.calculate_diffraction_pattern_gpu(
+        cls.pattern_0 = sg.calculate_diffraction_pattern_gpu(
             cls.pos_recip, cls.particle_0, return_type="complex_field")
 
         # Second Particle
         cls.part_coord_1 = np.array((0.5, 0.2, 0.1))  # Angstrom
-        cls.particle_1 = ps.Particle()
+        cls.particle_1 = sp.Particle()
         cls.particle_1.create_from_atoms([  # Angstrom
             ("O", cst.vecx + cls.part_coord_1),
             ("O", 2*cst.vecy + cls.part_coord_1),
             ("O", 3*cst.vecz + cls.part_coord_1),
         ])
         cls.part_coord_1 *= 1e-10  # Angstrom -> meter
-        cls.pattern_1 = pg.calculate_diffraction_pattern_gpu(
+        cls.pattern_1 = sg.calculate_diffraction_pattern_gpu(
             cls.pos_recip, cls.particle_1, return_type="complex_field")
 
     def test_add_phase_shift(self):
@@ -66,7 +66,7 @@ class TestDetectorBase(object):
 
 def test_distance_change():
     """Test distance property change."""
-    det = ps.SimpleSquareDetector(
+    det = sp.SimpleSquareDetector(
         N_pixel=1024, det_size=0.1, det_distance=0.2)
     distance_1 = det.distance
     pixel_position_1 = det.pixel_position.copy()

--- a/skopi/detector/tests/test_detector_base.py
+++ b/skopi/detector/tests/test_detector_base.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import pytest
 
-import skopi as sp
+import skopi as sk
 import skopi.gpu as sg
 import skopi.constants as cst
 from skopi.util import xp
@@ -21,10 +21,10 @@ class TestDetectorBase(object):
         ex_dir_ = os.path.dirname(__file__) + '/../../../examples'
 
         # Load beam
-        beam = sp.Beam(ex_dir_+'/input/beam/amo86615.beam')
+        beam = sk.Beam(ex_dir_+'/input/beam/amo86615.beam')
 
         # Load and initialize the detector
-        det = sp.PnccdDetector(
+        det = sk.PnccdDetector(
             geom=ex_dir_+'/input/lcls/amo86615/'
                  'PNCCD::CalibV1/Camp.0:pnCCD.1/geometry/0-end.data',
             beam=beam)
@@ -33,7 +33,7 @@ class TestDetectorBase(object):
         cls.pos_recip = det.pixel_position_reciprocal
 
         # Ref Particle
-        cls.particle_0 = sp.Particle()
+        cls.particle_0 = sk.Particle()
         cls.particle_0.create_from_atoms([  # Angstrom
             ("O", cst.vecx),
             ("O", 2*cst.vecy),
@@ -44,7 +44,7 @@ class TestDetectorBase(object):
 
         # Second Particle
         cls.part_coord_1 = np.array((0.5, 0.2, 0.1))  # Angstrom
-        cls.particle_1 = sp.Particle()
+        cls.particle_1 = sk.Particle()
         cls.particle_1.create_from_atoms([  # Angstrom
             ("O", cst.vecx + cls.part_coord_1),
             ("O", 2*cst.vecy + cls.part_coord_1),
@@ -66,7 +66,7 @@ class TestDetectorBase(object):
 
 def test_distance_change():
     """Test distance property change."""
-    det = sp.SimpleSquareDetector(
+    det = sk.SimpleSquareDetector(
         N_pixel=1024, det_size=0.1, det_distance=0.2)
     distance_1 = det.distance
     pixel_position_1 = det.pixel_position.copy()

--- a/skopi/detector/tests/test_user_defined_detector.py
+++ b/skopi/detector/tests/test_user_defined_detector.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 import pytest
 
-import skopi as sp
+import skopi as sk
 import skopi.gpu as sg
 import skopi.constants as cst
 from skopi.util import xp
@@ -44,7 +44,7 @@ class TestUserDefinedDetector(object):
             'pixel map': p_map,
         }
 
-        cls.det = sp.UserDefinedDetector(geom=det_dict)
+        cls.det = sk.UserDefinedDetector(geom=det_dict)
 
     def test_shape(self):
         assert self.det.shape == self.det_shape

--- a/skopi/detector/tests/test_user_defined_detector.py
+++ b/skopi/detector/tests/test_user_defined_detector.py
@@ -2,10 +2,10 @@ import numpy as np
 import os
 import pytest
 
-import pysingfel as ps
-import pysingfel.gpu as pg
-import pysingfel.constants as cst
-from pysingfel.util import xp
+import skopi as sp
+import skopi.gpu as sg
+import skopi.constants as cst
+from skopi.util import xp
 
 
 class TestUserDefinedDetector(object):
@@ -44,7 +44,7 @@ class TestUserDefinedDetector(object):
             'pixel map': p_map,
         }
 
-        cls.det = ps.UserDefinedDetector(geom=det_dict)
+        cls.det = sp.UserDefinedDetector(geom=det_dict)
 
     def test_shape(self):
         assert self.det.shape == self.det_shape

--- a/skopi/geometry/tests/test_convert.py
+++ b/skopi/geometry/tests/test_convert.py
@@ -2,8 +2,8 @@ import itertools
 import numpy as np
 import pytest
 
-from pysingfel.geometry import convert, generate
-import pysingfel.constants as cst
+from skopi.geometry import convert, generate
+import skopi.constants as cst
 
 
 def test_angle_axis_to_rot3d_x():

--- a/skopi/geometry/tests/test_generate.py
+++ b/skopi/geometry/tests/test_generate.py
@@ -3,8 +3,8 @@ import numpy as np
 import scipy as sp
 import pytest
 
-from pysingfel.geometry import generate, convert
-import pysingfel.constants as cst
+from skopi.geometry import generate, convert
+import skopi.constants as cst
 
 
 def test_points_on_1sphere_4y():

--- a/skopi/geometry/tests/test_geometry.py
+++ b/skopi/geometry/tests/test_geometry.py
@@ -2,8 +2,8 @@ import itertools
 import numpy as np
 import pytest
 
-from pysingfel import geometry
-import pysingfel.constants as cst
+from skopi import geometry
+import skopi.constants as cst
 
 
 def test_get_reciprocal_mesh_shape_even():

--- a/skopi/geometry/tests/test_mapping.py
+++ b/skopi/geometry/tests/test_mapping.py
@@ -2,8 +2,8 @@ import itertools
 import numpy as np
 import pytest
 
-from pysingfel.geometry import mapping
-from pysingfel.util import xp
+from skopi.geometry import mapping
+from skopi.util import xp
 
 
 def test_get_weight_and_index_center_odd():

--- a/skopi/geometry/tests/test_slice_.py
+++ b/skopi/geometry/tests/test_slice_.py
@@ -5,7 +5,7 @@ import h5py as h5
 import time
 import pytest
 
-import skopi as sp
+import skopi as sk
 import skopi.constants as cst
 from skopi.geometry import slice_
 from skopi.util import xp
@@ -31,49 +31,49 @@ class TestSlice(object):
         """Test take_slice on center value."""
         orientation = cst.quat1
         pixel_momentum = xp.array([[[[0., 0., 0.]]]])
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                pixel_momentum, orientation)
         assert xp.isclose(slice_[0, 0, 0], self.volume.mean())
 
     def test_take_slice_default_orientation(self):
         """Test take_slice with the default orientation."""
         orientation = cst.quat1
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_, self.volume)
 
     def test_take_slice_x_orientation(self):
         """Test take_slice with 180 degrees x rotation."""
         orientation = cst.quatx
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, ::-1, ::-1], self.volume)
 
     def test_take_slice_y_orientation(self):
         """Test take_slice with 180 degrees y rotation."""
         orientation = cst.quaty
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[::-1, :, ::-1], self.volume)
 
     def test_take_slice_z_orientation(self):
         """Test take_slice with 180 degrees z rotation."""
         orientation = cst.quatz
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[::-1, ::-1, :], self.volume)
 
     def test_take_slice_x90_orientation(self):
         """Test take_slice with 90 degrees x rotation."""
         orientation = cst.quatx90
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, :, ::-1].swapaxes(1, 2), self.volume)
 
     def test_take_slice_x270_orientation(self):
         """Test take_slice with 270 degrees x rotation."""
         orientation = cst.quatx270
-        slice_ = sp.take_slice(self.volume, self.voxel_length,
+        slice_ = sk.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, ::-1, :].swapaxes(1, 2), self.volume)
 
@@ -82,7 +82,7 @@ class TestSlice(object):
         # Slices
         orientations = np.vstack(
             [cst.quaty90, cst.quaty270, cst.quatz90, cst.quatz270])
-        slices = sp.take_n_slices(self.volume, self.voxel_length,
+        slices = sk.take_n_slices(self.volume, self.voxel_length,
                                   self.pixel_momentum, orientations)
         assert xp.allclose(slices[0, ::-1, :, :].swapaxes(0, 2), self.volume)
         assert xp.allclose(slices[1, :, :, ::-1].swapaxes(0, 2), self.volume)

--- a/skopi/geometry/tests/test_slice_.py
+++ b/skopi/geometry/tests/test_slice_.py
@@ -5,10 +5,10 @@ import h5py as h5
 import time
 import pytest
 
-import pysingfel as ps
-import pysingfel.constants as cst
-from pysingfel.geometry import slice_
-from pysingfel.util import xp
+import skopi as sp
+import skopi.constants as cst
+from skopi.geometry import slice_
+from skopi.util import xp
 
 
 class TestSlice(object):
@@ -31,49 +31,49 @@ class TestSlice(object):
         """Test take_slice on center value."""
         orientation = cst.quat1
         pixel_momentum = xp.array([[[[0., 0., 0.]]]])
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                pixel_momentum, orientation)
         assert xp.isclose(slice_[0, 0, 0], self.volume.mean())
 
     def test_take_slice_default_orientation(self):
         """Test take_slice with the default orientation."""
         orientation = cst.quat1
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_, self.volume)
 
     def test_take_slice_x_orientation(self):
         """Test take_slice with 180 degrees x rotation."""
         orientation = cst.quatx
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, ::-1, ::-1], self.volume)
 
     def test_take_slice_y_orientation(self):
         """Test take_slice with 180 degrees y rotation."""
         orientation = cst.quaty
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[::-1, :, ::-1], self.volume)
 
     def test_take_slice_z_orientation(self):
         """Test take_slice with 180 degrees z rotation."""
         orientation = cst.quatz
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[::-1, ::-1, :], self.volume)
 
     def test_take_slice_x90_orientation(self):
         """Test take_slice with 90 degrees x rotation."""
         orientation = cst.quatx90
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, :, ::-1].swapaxes(1, 2), self.volume)
 
     def test_take_slice_x270_orientation(self):
         """Test take_slice with 270 degrees x rotation."""
         orientation = cst.quatx270
-        slice_ = ps.take_slice(self.volume, self.voxel_length,
+        slice_ = sp.take_slice(self.volume, self.voxel_length,
                                self.pixel_momentum, orientation)
         assert xp.allclose(slice_[:, ::-1, :].swapaxes(1, 2), self.volume)
 
@@ -82,7 +82,7 @@ class TestSlice(object):
         # Slices
         orientations = np.vstack(
             [cst.quaty90, cst.quaty270, cst.quatz90, cst.quatz270])
-        slices = ps.take_n_slices(self.volume, self.voxel_length,
+        slices = sp.take_n_slices(self.volume, self.voxel_length,
                                   self.pixel_momentum, orientations)
         assert xp.allclose(slices[0, ::-1, :, :].swapaxes(0, 2), self.volume)
         assert xp.allclose(slices[1, :, :, ::-1].swapaxes(0, 2), self.volume)


### PR DESCRIPTION
Is there a preference between `import skopi as sk` and `import skopi as sp`? Perhaps this is an unlikely conflict, but I wasn't sure if `sklearn` is typically abbreviated as `sk`.