### PR TITLE
Adding functions to introduce beam jitter and sloped background

### DIFF
--- a/skopi/experiment/base.py
+++ b/skopi/experiment/base.py
@@ -9,6 +9,7 @@ class Experiment(object):
     def __init__(self, det, beam, particles):
         self.det = det
         self.beam = beam
+        self.particles = particles
         self.n_particle_kinds = len(particles)
 
         # Create mesh
@@ -30,6 +31,9 @@ class Experiment(object):
         # soon obsolete flag to handle multi particle hit
         self.multi_particle_hit = False
 
+        # set up list to track diplacements from beam center
+        self.beam_displacements = list()
+
     def generate_image(self, return_orientation=False):
         if return_orientation:
             img_stack, orientation = self.generate_image_stack(return_orientation=return_orientation)
@@ -41,7 +45,7 @@ class Experiment(object):
     def generate_image_stack(self, return_photons=None,
                              return_intensities=False,
                              return_orientation=False,
-                             always_tuple=False):
+                             always_tuple=False, noise={}):
         """
         Generate and return a snapshot of the experiment.
 
@@ -55,6 +59,9 @@ class Experiment(object):
         arrays instead of the array itself.
         To return a tuple even if only one array is requested, set
         always_tuple to True.
+
+        Noise is introduced based on contents of noise parameter. Dark
+        noise, beam jitter, and static noise are currently implemented.
         """
         if return_photons is None and return_intensities is False:
             return_photons = True
@@ -67,18 +74,37 @@ class Experiment(object):
 
         orientations = sample_state[0][1]
 
+        if ('jitter' in noise.keys()) and (noise['jitter']!=0):
+            displacement = self.det.add_beam_jitter(noise['jitter'])
+            self.beam_displacements.append(displacement)
+
         for spike in beam_spectrum:
             recidet = ReciprocalDetector(self.det, spike)
 
             group_complex_pattern = 0.
             for i, particle_group in enumerate(sample_state):
-                group_complex_pattern += self._generate_group_complex_pattern(
+                next_pattern = self._generate_group_complex_pattern(
                     recidet, i, particle_group)
+                if np.sum(next_pattern) == 0:
+                    print("Using direct calculation instead")
+                    next_pattern = self._direct_calculate(recidet, particle_group)
+                group_complex_pattern += next_pattern
 
             group_pattern = np.abs(group_complex_pattern)**2
 
-            group_intensities = recidet.add_correction(group_pattern)
+            # corrections are based on miscentered beam if there's jitter
+            group_intensities = self.det.add_correction(group_pattern) 
             intensities_stack += group_intensities
+
+        # add static noise to sum of all spikes and particles
+        if 'static' in noise.keys() and noise['static'] is True:
+            intensities_stack = self.det.add_static_noise(intensities_stack)
+
+        # add sloped background incoherently
+        if 'sloped' in noise.keys():
+            if noise['sloped'].shape != self.det.shape:
+                noise['sloped'] = self.det.disassemble_image_stack(noise['sloped'])
+            intensities_stack += noise['sloped']
 
         # We are summing up intensities then converting to photons as opposed to converting to photons then summing up.
         # Note: We may want to revisit the correctness of this procedure.
@@ -113,6 +139,31 @@ class Experiment(object):
             slices[j] = recidet.add_phase_shift(slices[j], position)
 
         return slices.sum(axis=0)
+
+    def _direct_calculate(self, recidet, particle_group):
+        """
+        Compute patterns using the Detector class, so directly at reciprocal
+        space positions of interest.
+    
+        :param recidet: ReciprocalDetector object
+        :param particle_group: list of positions and orientations per particle
+        :return pattern: complex field for particle group
+        """
+        positions, orientations = particle_group
+        pattern = 0
+    
+        for j in range(len(orientations)):
+            self.particles[j].rotate(orientations[j])
+            next_slice = recidet.get_pattern_without_corrections(self.particles[j], return_type='complex_field')
+            pattern += recidet.add_phase_shift(next_slice, positions[j])
+
+            # unrotate particle
+            rot_mat = psg.convert.quaternion2rot3d(orientations[j])
+            rot_mat_inv = np.linalg.inv(rot_mat)
+            quat_inv = psg.convert.rotmat_to_quaternion(rot_mat_inv)
+            self.particles[j].rotate(quat_inv)
+        
+        return pattern
 
     def generate_new_sample_state(self):
         """

--- a/skopi/geometry/slice_.py
+++ b/skopi/geometry/slice_.py
@@ -31,7 +31,7 @@ def extract_slice(local_index, local_weight, volume):
     :param local_index: The index containing values to take.
     :param local_weight: The weight for each index.
     :param volume: The volume to slice from.
-    :return: The slice.
+    :return: The slice or an array of zeros is if dimensions are incompatible.
     """
     local_index = xp.asarray(local_index)
     local_weight = xp.asarray(local_weight)
@@ -52,7 +52,11 @@ def extract_slice(local_index, local_weight, volume):
     weight_2d = xp.reshape(local_weight, [pixel_num, 8])
 
     # Expand the data to merge
-    data_to_merge = volume_1d[index_2d]
+    try:
+        data_to_merge = volume_1d[index_2d]
+    except IndexError:
+        print("Requested slice and diffraction volume have incompatible dimensions")
+        return np.zeros(pattern_shape)
 
     # Merge the data
     data_merged = xp.sum(xp.multiply(weight_2d, data_to_merge), axis=-1)


### PR DESCRIPTION
The Experiment and Detector classes have been modified to enable introducing beam jitter and sloped background. For the former, displacements from the ideal center are drawn from a Gaussian distribution and assumed to be uncorrelated along the x and y dimensions of the detector. It was checked that for the same beam displacements, the results of the direct calculation (Detector class) and the indirect calculation (Experiment class) are the same within interpolation error:

![download](https://user-images.githubusercontent.com/6363287/109082808-7b06c280-76b9-11eb-8310-095523796113.png)

For the sloped background, the user must supply the desired sloped background pattern in the shape of the detector. An example is shown below.

![download-1](https://user-images.githubusercontent.com/6363287/109082820-7e9a4980-76b9-11eb-8f91-f1b38746e069.png)
