### PR TITLE
Revisions to the holography experiment class

### DIFF
--- a/examples/scripts/ExampleHolography.py
+++ b/examples/scripts/ExampleHolography.py
@@ -44,7 +44,8 @@ particle2.read_pdb(pdbfile2, ff='WK')
 
 # Perform Holography experiment
 tic = time.time()
-experiment = sk.HOLOExperiment(det=det, beam=beam, reference=[particle], particles=[particle2], ref_position=np.array([[0., 0., 0.]]), part_positions=np.array([[[0., 1e-7, 0.]]]))
+experiment = sk.HOLOExperiment(det=det, beam=beam, reference=[particle], particles=[particle2], 
+                               ref_position=np.array([[0., 0., 0.]]), part_positions=np.array([[0., 1e-7, 0.]]), jet_radius=1e-7, ref_jet_radius=1e-7)
 toc = time.time()
 print(">>> It took {:.2f} seconds to finish Holography calculation.".format(toc-tic))
 

--- a/skopi/experiment/holo.py
+++ b/skopi/experiment/holo.py
@@ -1,6 +1,7 @@
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plt
+from collections import Counter
 import skopi.geometry as psg
 import skopi as ps
 from skopi.particlePlacement import *
@@ -13,21 +14,29 @@ class HOLOExperiment(Experiment):
     Class for holography experiment.
     """
 
-    def __init__(self, det, beam, reference, particles, ref_position=None, ref_orientation=None, part_positions=None, part_orientations=None):
+    def __init__(self, det, beam, reference, particles, jet_radius, ref_jet_radius,
+                 ref_position=None, ref_orientation=None, part_positions=None, part_orientations=None):
         """
-        Initialize a holography experiment.
+        Initialize a holography experiment. Here we assume a single reference
+        particle and n target particles.
         
         :param det: The detector object.
         :param beam: The beam object.
         :param reference: The reference particle object.
         :param particles: The sample particle objects.
+        :param jet_radius: The radius of the aerosolized jet used to deliver target particles.
+        :param ref_jet_radius: The radius of the aerosolized jet used to deliver the reference particle.
         :param ref_position: The position of the reference particle object.
         :param ref_orientation: The orientation of the reference particle object.
         :param part_positions: The positions of the sample particle objects.
         :param part_orientations: The orientations of the sample particle objects.
         """
-        super(HOLOExperiment, self).__init__(det, beam, particles)
+        super(HOLOExperiment, self).__init__(det, beam, reference + particles)
+        self.n_target_particles = len(particles)
+        self.particles = particles
         self.reference = reference
+        self.jet_radius = jet_radius
+        self.ref_jet_radius = ref_jet_radius
         self.set_ref_position(ref_position)
         self.set_ref_orientation(ref_orientation)
         self.set_part_positions(part_positions)        
@@ -41,7 +50,6 @@ class HOLOExperiment(Experiment):
         where the positions and orientations have one line
         per particle in the sample at this state.
         """
-        particle_groups = []
         part_orientations = self.get_next_part_orientation()
         part_positions = self.get_next_part_position()
         ref_orientation = self.get_ref_orientation()
@@ -50,7 +58,7 @@ class HOLOExperiment(Experiment):
             raise TypeError("Missing reference particle orientation or position")
         positions = np.concatenate((ref_position,part_positions), axis=0)
         orientations = np.concatenate((ref_orientation,part_orientations), axis=0)
-        particle_groups.append((positions, orientations))
+        particle_groups = [(np.array([p]),np.array([o])) for p,o in zip(positions,orientations)]
         return particle_groups
 
     def get_ref_orientation(self):
@@ -72,7 +80,9 @@ class HOLOExperiment(Experiment):
         Return the position.
         """
         if self._ref_position is None:
-            return np.array([[0.,0.,0.]])
+            return random_positions_in_beam(1, 
+                                            min(self.jet_radius, self.ref_jet_radius),
+                                            max(self.jet_radius, self.ref_jet_radius))
 
         ref_position = self._ref_position
 
@@ -86,14 +96,15 @@ class HOLOExperiment(Experiment):
         Return the next orientation.
         """
         if self._part_orientations is None:
-            return psg.get_random_quat(1)
+            return psg.get_random_quat(self.n_target_particles)
 
         if self._i_part_orientations >= len(self._part_orientations):
             raise StopIteration("No more orientation available.")
 
-        part_orientation = self._part_orientations[self._i_part_orientations]
+        part_orientation = self._part_orientations[self._i_part_orientations:
+                                                   self._i_part_orientations+self.n_target_particles]
 
-        self._i_part_orientations += 1
+        self._i_part_orientations += self.n_target_particles
         return part_orientation
 
     def set_part_orientations(self, part_orientations):
@@ -105,14 +116,20 @@ class HOLOExperiment(Experiment):
         Return the next position.
         """
         if self._part_positions is None:
-            return np.array([[0., 0., 0.]])
+            particle_dict = dict(Counter(self.particles))
+            states, coords = distribute_particles(particle_dict, 
+                                                  min(self.jet_radius, self.ref_jet_radius), 
+                                                  max(self.jet_radius, self.ref_jet_radius), 
+                                                  sticking=False, iteration=0, max_iter=10)
+            return coords
 
         if self._i_part_positions >= len(self._part_positions):
             raise StopIteration("No more position available.")
 
-        part_position = self._part_positions[self._i_part_positions]
+        part_position = self._part_positions[self._i_part_positions:
+                                             self._i_part_positions+self.n_target_particles]
 
-        self._i_part_positions += 1
+        self._i_part_positions += self.n_target_particles
         return part_position
 
     def set_part_positions(self, part_positions):


### PR DESCRIPTION
The following changes were made:
- If particle positions are not supplied, these are computed by randomly distributing particles in the volume intersected by the reference and target particle gas jets, rather than setting both to the origin. The jets' radii must now be supplied in setting up a holography object.
- The diffraction volume for the reference particle is calculated during initialization; previously only the diffraction volume(s) of the target particle(s) was/were computed.
- The example holography script has been updated accordingly.

The figure below compares images from holography and SPI experiments, where the target particle is the same and similarly oriented. In the holography case, there is also a reference particle in the beam -- in this case, a small cluster of gold atoms. As a check, the SPI pattern was also computed using the detector class to verify that the experiment and detector classes yield the same results.

![download-1](https://user-images.githubusercontent.com/6363287/114818158-248c3b00-9d70-11eb-998f-be908f051afb.png)
